### PR TITLE
Add a github workflow to publish to PyPI.org

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -14,7 +14,7 @@ name: Publish to PyPI
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'  # Trigger only on version tags like v1.0.0
+      - 'v[0-9]*.[0-9]*.[0-9]*'  # Trigger only on version tags like v1.0.0
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
To use this:
1. As a one-time operation, add a trusted publisher to the existing PyPI project per instructions at https://docs.pypi.org/trusted-publishers/adding-a-publisher/
2. To do a release: push a tag of the form "v1.0.0" to github for whatever the version number is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated publishing to PyPI: pushing a version tag now triggers a build and publishes distribution artifacts automatically. This streamlines releases, reduces manual steps, and lowers risk of human error by ensuring reproducible, faster package releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->