### PR TITLE
Allow configuring an offset between folder creation and audio start

### DIFF
--- a/src/orca_hls_utils/DateRangeHLSStream.py
+++ b/src/orca_hls_utils/DateRangeHLSStream.py
@@ -38,8 +38,9 @@ class DateRangeHLSStream:
     wav_dir
     overwrite_output: allows ffmpeg to overwrite output, default is False
     real_time: if False, get data as soon as possible, if true wait for
-                polling interval before pulling
-    audio_offset: delay after stream_id before first audio clip was started
+               polling interval before pulling
+    audio_offset: delay in seconds after stream_id before first audio
+                  clip was started
     """
 
     def __init__(

--- a/src/orca_hls_utils/DateRangeHLSStream.py
+++ b/src/orca_hls_utils/DateRangeHLSStream.py
@@ -52,7 +52,7 @@ class DateRangeHLSStream:
         wav_dir,
         overwrite_output=False,
         real_time=False,
-        audio_offset=2
+        audio_offset=2,
     ):
         """ """
 
@@ -157,7 +157,9 @@ class DateRangeHLSStream:
         # an offset here to compensate.
         time_since_folder_start -= self.audio_offset
 
-        segment_start_index = math.ceil(time_since_folder_start / target_duration)
+        segment_start_index = math.ceil(
+            time_since_folder_start / target_duration
+        )
         segment_end_index = segment_start_index + num_segments_in_wav_duration
 
         if segment_end_index > num_total_segments:

--- a/src/orca_hls_utils/HLSStream.py
+++ b/src/orca_hls_utils/HLSStream.py
@@ -32,10 +32,11 @@ class HLSStream:
     polling_interval = 60 sec
     """
 
-    def __init__(self, stream_base, polling_interval, wav_dir):
+    def __init__(self, stream_base, polling_interval, wav_dir, audio_offset=2):
         self.stream_base = stream_base
         self.polling_interval = polling_interval
         self.wav_dir = wav_dir
+        self.audio_offset = audio_offset
         bucket_folder = self.stream_base.split(
             "https://s3-us-west-2.amazonaws.com/"
         )[1]
@@ -123,6 +124,12 @@ class HLSStream:
                 current_clip_end_time_unix_pst, stream_id
             )
         )
+
+        # Currently there is a delay between the stream_id time and
+        # the actual start of the audio stream in the folder, so add
+        # an offset here to compensate.
+        time_since_folder_start -= self.audio_offset
+
         if time_since_folder_start < self.polling_interval + 20:
             # This implies that possibly a new folder was created
             # and we do not have enough data for a 1 minute clip + 20 second


### PR DESCRIPTION
Default to 2 seconds based on actual observations of existing audio streams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio stream synchronization by compensating for delays between stream metadata and actual audio start, enhancing segment detection and processing accuracy.
  * Added a configurable audio timing offset (default 2s) so systems can fine-tune alignment between reported stream times and real audio playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->